### PR TITLE
Update initialScripts to initialDumps in passetto

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1696703188,
-        "narHash": "sha256-nX6n4/BNeTzVaPMhEKeKHociyAJh9vo4F2W5UoY/ffM=",
+        "lastModified": 1703583932,
+        "narHash": "sha256-TJFa4Ej1R2H2VKjZAa5FbkOV4mqYH+ZaZk1KQZUL/oc=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "c56d39116cbe835229e26171c8405cd311be067f",
+        "rev": "d6b73e401ef6279184c12d1791a7148aa0365f21",
         "type": "github"
       },
       "original": {

--- a/process-compose.nix
+++ b/process-compose.nix
@@ -38,7 +38,6 @@ in
     lib.mkIf cfg.enable {
       services.postgres."${srvname}-db" = {
         enable = true;
-        port = 5422;
         listen_addresses = "127.0.0.1";
         hbaConf = [
           # Equivalent to `POSTGRES_INITDB_ARGS = "--auth=scram-sha-256";`, sets the auth for all users

--- a/process-compose.nix
+++ b/process-compose.nix
@@ -18,16 +18,13 @@ in
             description = "Postgres connection string";
           };
           pgweb.enable = lib.mkEnableOption "Enable pgweb on passetto db";
-          initialScript = lib.mkOption {
-            type = lib.types.str;
-            default = "";
-            description = ''
-              Initial SQL Commands to run during databse initialization. This can be multiple 
-              SQL expressions separated by a semi-colon.
-              '';
+          initialDumps = lib.mkOption {
+            type = lib.types.listOf lib.types.path;
+            default = [ ];
+            description = ''List of SQL dumps to run during the database initialization.
+              These dumps are loaded after `initalScript` and `initialDatabases`.'';
             example = lib.literalExpression ''
-              CREATE USER postgres SUPERUSER;
-              CREATE USER bar;
+              [ ./foo.sql ./bar.sql ]
             '';
           };
         };
@@ -54,7 +51,8 @@ in
         initialScript.before = ''
           CREATE ROLE ${userName} SUPERUSER;
           ALTER ROLE ${userName} WITH LOGIN;
-        '' + "\n" + cfg.initialScript;
+        '';
+        initialDumps = cfg.initialDumps;
         initialDatabases = [
           {
             name = dbName;

--- a/process-compose.nix
+++ b/process-compose.nix
@@ -38,6 +38,7 @@ in
     lib.mkIf cfg.enable {
       services.postgres."${srvname}-db" = {
         enable = true;
+        port = 5422;
         listen_addresses = "127.0.0.1";
         hbaConf = [
           # Equivalent to `POSTGRES_INITDB_ARGS = "--auth=scram-sha-256";`, sets the auth for all users


### PR DESCRIPTION
Earlier we were using initialScripts options to load sql dump files and concatenating all files into one command. Now we can utilize initialDumps options which is present in postgres to directly load sql dumps.