### PR TITLE
[postgres] use `schemas`; `environment.PORT` belongs to `passetto-service`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,11 +93,11 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1703583932,
-        "narHash": "sha256-TJFa4Ej1R2H2VKjZAa5FbkOV4mqYH+ZaZk1KQZUL/oc=",
+        "lastModified": 1705395905,
+        "narHash": "sha256-KoA4lM/hPwAsX4WDyA5jNFm3wT8ASF4sCN2Hbev8zZU=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "d6b73e401ef6279184c12d1791a7148aa0365f21",
+        "rev": "c7bed59b874f367813966725ae390691c65cedff",
         "type": "github"
       },
       "original": {

--- a/process-compose.nix
+++ b/process-compose.nix
@@ -62,7 +62,7 @@ in
         initialDatabases = [
           {
             name = dbName;
-            schema = ./service/pgsql/create_schema.sql;
+            schemas = [ ./service/pgsql/create_schema.sql ];
           }
         ];
       };
@@ -70,12 +70,12 @@ in
         processes = {
           "${srvname}-pgweb" = lib.mkIf cfg.pgweb.enable {
             environment.PGWEB_DATABASE_URL = cfg.pgurl;
-            environment.PORT = builtins.toString cfg.port;
             command = pkgs.pgweb;
             depends_on."${srvname}-db".condition = "process_healthy";
           };
           passetto-service = { name, ... }: {
             environment.PASSETTO_PG_BACKEND_CONN_STRING = cfg.pgurl;
+            environment.PORT = builtins.toString cfg.port;
             depends_on."${srvname}-db".condition = "process_healthy";
             command = pkgs.writeShellApplication {
               inherit name;


### PR DESCRIPTION
schemas will eliminate the need for initialDumps which was added here: https://github.com/nammayatri/passetto/pull/5